### PR TITLE
fix docker version

### DIFF
--- a/base/hack/install_utils.sh
+++ b/base/hack/install_utils.sh
@@ -6,7 +6,7 @@ ARCH=$(uname -m)
 echo $ARCH
 
 # Docker
-DOCKER_VERSION=18.09.09
+DOCKER_VERSION=18.09.9
 if [[ ${ARCH} == 'x86_64' ]]; then
   curl -f https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz | tar xvz && \
   mv docker/docker /usr/bin/ && \


### PR DESCRIPTION
原本 18.09.09 的版本号生成的链接已经失效，导致重新构建的镜像 docker 安装失败。参考 https://download.docker.com/linux/static/stable/x86_64/