### PR TITLE
Add JAVA_HOME into env & fix the broken links of maven and ant

### DIFF
--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -1,21 +1,23 @@
 FROM kubespheredev/builder-base:latest
 
 # java
-RUN yum install -y java-1.8.0-openjdk-devel \
-    java-1.8.0-openjdk-devel.i686
+ENV JAVA_VERSIOIN 1.8.0
+RUN yum install -y java-${JAVA_VERSIOIN}-openjdk-devel \
+    java-${JAVA_VERSIOIN}-openjdk-devel.i686
 
 # maven
 ENV MAVEN_VERSION 3.5.3
-RUN curl -f -L http://central.maven.org/maven2/org/apache/maven/apache-maven/$MAVEN_VERSION/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar -C /opt -xzv
+RUN curl -f -L https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar -C /opt -xzv
 ENV M2_HOME /opt/apache-maven-$MAVEN_VERSION
+ENV JAVA_HOME /usr/lib/jvm/java-${JAVA_VERSIOIN}-openjdk
 ENV maven.home $M2_HOME
 ENV M2 $M2_HOME/bin
-ENV PATH $M2:$PATH
+ENV PATH $M2:$PATH:JAVA_HOME/bin
 
 # ant
 ENV ANT_VERSION 1.10.7
 RUN cd && \
-    wget -q http://www.us.apache.org/dist//ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz && \
+    wget -q https://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz && \
     tar -xzf apache-ant-${ANT_VERSION}-bin.tar.gz && \
     mv apache-ant-${ANT_VERSION} /opt/ant && \
     rm apache-ant-${ANT_VERSION}-bin.tar.gz


### PR DESCRIPTION
Firstly, I need to say sorry about this PR. I didn't notice that I created a branch from `kubesphere` instead of my personal account.

I did two things here.

* Add a JAVA_HOME as the environment
  * Some CLI or program depends on JAVA_HOME
* Change the links of maven and ant
  * The previous links are broken, you can see the detail below

```
➜  kubesphere export MAVEN_VERSION=3.5.3
➜  kubesphere export ANT_VERSION=1.10.7

➜  kubesphere curl -I -L -v http://central.maven.org/maven2/org/apache/maven/apache-maven/$MAVEN_VERSION/apache-maven-$MAVEN_VERSION-bin.tar.gz
* Could not resolve host: central.maven.org
* Closing connection 0
curl: (6) Could not resolve host: central.maven.org

➜  kubesphere curl -I -L http://www.us.apache.org/dist//ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz
HTTP/1.1 302 Found
Date: Mon, 28 Dec 2020 11:59:54 GMT
Server: Apache/2.4.18 (Ubuntu)
Location: https://downloads.apache.org/ant/binaries/apache-ant-1.10.7-bin.tar.gz
Cache-Control: max-age=3600
Expires: Mon, 28 Dec 2020 12:59:54 GMT
Content-Type: text/html; charset=iso-8859-1

HTTP/1.1 404 Not Found
Date: Mon, 28 Dec 2020 11:59:56 GMT
Server: Apache
Content-Type: text/html; charset=iso-8859-1
```