### PR TITLE
Add helm version 3 and keep helm 2 exist

### DIFF
--- a/base/hack/install_utils.sh
+++ b/base/hack/install_utils.sh
@@ -23,18 +23,27 @@ fi
 
 # Helm
 HELM_VERSION=2.11.0
+HELM3_VERSIOIN=3.5.0
 
 if [[ ${ARCH} == 'x86_64' ]]; then
   curl -f https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz  | tar xzv && \
   mv linux-amd64/helm /usr/bin/ && \
   mv linux-amd64/tiller /usr/bin/ && \
   rm -rf linux-amd64
+
+  curl -f https://get.helm.sh/helm-v${HELM3_VERSIOIN}-linux-amd64.tar.gz | tar xzv && \
+  mv linux-amd64/helm /usr/bin/helm3 && \
+  rm -rf linux-amd64 
 elif [[ ${ARCH} == 'aarch64' ]]
 then
   curl -f https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-arm64.tar.gz  | tar xzv && \
   mv linux-arm64/helm /usr/bin/ && \
   mv linux-arm64/tiller /usr/bin/ && \
   rm -rf linux-arm64
+
+  curl -f https://get.helm.sh/helm-v${HELM3_VERSIOIN}-linux-arm64.tar.gz | tar xzv && \
+  mv linux-arm64/helm /usr/bin/helm3 && \
+  rm -rf linux-arm64 
 else
   echo "do not support this arch"
   exit 1


### PR DESCRIPTION
Let's don't remove helm 2 for now until next release of KubeSphere. For example, remove helm 2 in 4.x.