### PR TITLE
Add docker login and gh repo fork

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,5 +3,8 @@ image:
 
 tasks:
   - init: |
+      [[ ! -z "${DOCKER_USER}" && ! -z "${DOCKER_PASSWD}" ]] && docker login -u${DOCKER_USER} -p${DOCKER_PASSWD}
+      [[ ! -z "${GITHUB_USER}" && ! -z "${GITHUB_TOKEN}" ]] && docker login ghcr.io -u${GITHUB_USER} -p${GITHUB_TOKEN}
       git config --global user.name $GIT_AUTHOR_NAME
       git config --global user.email $GIT_COMMITTER_EMAIL
+      gh repo fork --remote


### PR DESCRIPTION
It's convenient if run docker login in the GitPod environment automatically.

The second benefit is that this script can fork the repository automatically.