### PR TITLE
Fix the invalid keyserver of gpg

### DIFF
--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -23,9 +23,7 @@ RUN ARCH= && uArch="$(uname -m)" \
     A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
     B9E2F5981AA6E0CD28160D9FF13993A75599653C \
   ; do \
-    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+    gpg --batch --keyserver sks.srv.dumain.com --recv-keys "$key"; \
   done \
   && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
   && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \


### PR DESCRIPTION
Before:
```
gitpod /workspace/devops-agent $ gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys B9E2F5981AA6E0CD28160D9FF13993A75599653C
gpg: keyserver receive failed: No name
```

After:
```
gitpod /workspace/devops-agent $ gpg --batch --keyserver sks.srv.dumain.com --recv-keys B9E2F5981AA6E0CD28160D9FF13993A75599653C
gpg: key F13993A75599653C: public key "Shelley Vohr (security is major key) <shelley.vohr@gmail.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
```

Get more details from https://github.com/nodejs/node/pull/39731#issue-708387641