### PR TITLE
Add podman in the base, maven, go, nodejs images

### DIFF
--- a/.github/workflows/build-podman.yaml
+++ b/.github/workflows/build-podman.yaml
@@ -1,0 +1,292 @@
+name: Build Podman Images
+
+on:
+  push:
+    branches:
+    - master
+    - test-* # make it be easier for contributors to test
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - 'master'
+
+jobs:
+  BuildBase:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Docker meta for KubeSphere
+      id: meta
+      if: github.repository_owner == 'kubesphere'
+      uses: docker/metadata-action@v3
+      with:
+        images: |
+          kubespheredev/builder-base
+          ghcr.io/${{ github.repository_owner }}/builder-base
+        tags: |
+          type=schedule
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern=v{{version}}-podman
+          type=sha
+    - name: Docker meta for Contributors
+      id: metaContributors
+      if: github.repository_owner != 'kubesphere'
+      uses: docker/metadata-action@v3
+      with:
+        images: |
+          ghcr.io/${{ github.repository_owner }}/builder-base
+        tags: |
+          type=schedule
+          type=ref,event=branch,suffix=-podman
+          type=ref,event=pr,suffix=-podman
+          type=semver,pattern=v{{version}}-podman
+          type=sha,suffix=-podman
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_SECRETS }}
+    - name: Login to GHCR
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_TOKEN }}
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v2.4.0
+      if: github.repository_owner == 'kubesphere'
+      with:
+        context: base
+        file: base/podman/Dockerfile
+        tags: ${{ steps.meta.outputs.tags }}
+        push: ${{ github.event_name != 'pull_request' }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64
+    - name: Build and push Docker images for Contributors
+      uses: docker/build-push-action@v2.4.0
+      if: github.repository_owner != 'kubesphere'
+      with:
+        context: base
+        file: base/podman/Dockerfile
+        tags: ${{ steps.metaContributors.outputs.tags }}
+        push: ${{ github.event_name != 'pull_request' }}
+        labels: ${{ steps.metaContributors.outputs.labels }}
+        platforms: linux/amd64
+
+  BuildGo:
+    needs: BuildBase
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Docker meta for KubeSphere
+      id: meta
+      if: github.repository_owner == 'kubesphere'
+      uses: docker/metadata-action@v3
+      with:
+        images: |
+          kubespheredev/builder-go
+          ghcr.io/${{ github.repository_owner }}/builder-go
+        tags: |
+          type=schedule
+          type=ref,event=branch,suffix=-podman
+          type=ref,event=pr,suffix=-podman
+          type=semver,pattern=v{{version}}-podman
+          type=sha,suffix=-podman
+    - name: Docker meta for Contributors
+      id: metaContributors
+      if: github.repository_owner != 'kubesphere'
+      uses: docker/metadata-action@v3
+      with:
+        images: |
+          ghcr.io/${{ github.repository_owner }}/builder-go
+        tags: |
+          type=schedule
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern=v{{version}}-podman
+          type=sha
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_SECRETS }}
+    - name: Login to GHCR
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_TOKEN }}
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v2.4.0
+      if: github.repository_owner == 'kubesphere'
+      with:
+        context: go
+        file: go/podman/Dockerfile
+        tags: ${{ steps.meta.outputs.tags }}
+        push: ${{ github.event_name != 'pull_request' }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64
+    - name: Build and push Docker images for Contributors
+      uses: docker/build-push-action@v2.4.0
+      if: github.repository_owner != 'kubesphere'
+      with:
+        context: go
+        file: go/podman/Dockerfile
+        tags: ${{ steps.metaContributors.outputs.tags }}
+        push: ${{ github.event_name != 'pull_request' }}
+        labels: ${{ steps.metaContributors.outputs.labels }}
+        platforms: linux/amd64
+
+  BuildMaven:
+    needs: BuildBase
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Docker meta for KubeSphere
+      id: meta
+      if: github.repository_owner == 'kubesphere'
+      uses: docker/metadata-action@v3
+      with:
+        images: |
+          kubespheredev/builder-maven
+          ghcr.io/${{ github.repository_owner }}/builder-maven
+        tags: |
+          type=schedule
+          type=ref,event=branch,suffix=-podman
+          type=ref,event=pr,suffix=-podman
+          type=semver,pattern=v{{version}}-podman
+          type=sha,suffix=-podman
+    - name: Docker meta for Contributors
+      id: metaContributors
+      if: github.repository_owner != 'kubesphere'
+      uses: docker/metadata-action@v3
+      with:
+        images: |
+          ghcr.io/${{ github.repository_owner }}/builder-maven
+        tags: |
+          type=schedule
+          type=ref,event=branch,suffix=-podman
+          type=ref,event=pr,suffix=-podman
+          type=semver,pattern=v{{version}}-podman
+          type=sha,suffix=-podman
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_SECRETS }}
+    - name: Login to GHCR
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_TOKEN }}
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v2.4.0
+      if: github.repository_owner == 'kubesphere'
+      with:
+        context: maven
+        file: maven/podman/Dockerfile
+        tags: ${{ steps.meta.outputs.tags }}
+        push: ${{ github.event_name != 'pull_request' }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64
+    - name: Build and push Docker images for Contributors
+      uses: docker/build-push-action@v2.4.0
+      if: github.repository_owner != 'kubesphere'
+      with:
+        context: maven
+        file: maven/podman/Dockerfile
+        tags: ${{ steps.metaContributors.outputs.tags }}
+        push: ${{ github.event_name != 'pull_request' }}
+        labels: ${{ steps.metaContributors.outputs.labels }}
+        platforms: linux/amd64
+
+  BuildNodeJs:
+    needs: BuildBase
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Docker meta for KubeSphere
+      id: meta
+      if: github.repository_owner == 'kubesphere'
+      uses: docker/metadata-action@v3
+      with:
+        images: |
+          kubespheredev/builder-nodejs
+          ghcr.io/${{ github.repository_owner }}/builder-nodejs
+        tags: |
+          type=schedule
+          type=ref,event=branch,suffix=-podman
+          type=ref,event=pr,suffix=-podman
+          type=semver,pattern=v{{version}}-podman
+          type=sha,suffix=-podman
+    - name: Docker meta for Contributors
+      id: metaContributors
+      if: github.repository_owner != 'kubesphere'
+      uses: docker/metadata-action@v3
+      with:
+        images: |
+          ghcr.io/${{ github.repository_owner }}/builder-nodejs
+        tags: |
+          type=schedule
+          type=ref,event=branch,suffix=-podman
+          type=ref,event=pr,suffix=-podman
+          type=semver,pattern=v{{version}}-podman
+          type=sha,suffix=-podman
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_SECRETS }}
+    - name: Login to GHCR
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_TOKEN }}
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v2.4.0
+      if: github.repository_owner == 'kubesphere'
+      with:
+        context: nodejs
+        file: nodejs/podman/Dockerfile
+        tags: ${{ steps.meta.outputs.tags }}
+        push: ${{ github.event_name != 'pull_request' }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64
+    - name: Build and push Docker images for Contributors
+      uses: docker/build-push-action@v2.4.0
+      if: github.repository_owner != 'kubesphere'
+      with:
+        context: nodejs
+        file: nodejs/podman/Dockerfile
+        tags: ${{ steps.metaContributors.outputs.tags }}
+        push: ${{ github.event_name != 'pull_request' }}
+        labels: ${{ steps.metaContributors.outputs.labels }}
+        platforms: linux/amd64

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+COMMIT := $(shell git rev-parse --short HEAD)
+VERSION := dev-$(shell git describe --tags $(shell git rev-list --tags --max-count=1))
+
+build-base-podman:
+	docker build base -f base/podman/Dockerfile -t kubespheredev/builder-base:$(VERSION)-podman
+push-base-podman:
+	docker push kubespheredev/builder-base:$(VERSION)-podman
+
+build-maven-podman:
+	docker build maven -f maven/podman/Dockerfile -t kubespheredev/builder-maven:$(VERSION)-podman
+push-maven-podman:
+	docker push kubespheredev/builder-maven:$(VERSION)-podman
+

--- a/base/README.md
+++ b/base/README.md
@@ -1,4 +1,4 @@
-There're two base images base on different container runtime here:
+There're two base images based on different container runtime:
 
 * Docker
 * Podman

--- a/base/README.md
+++ b/base/README.md
@@ -1,0 +1,14 @@
+There're two base images base on different container runtime here:
+
+* Docker
+* Podman
+
+## Podman
+
+In order to make it be easy to use. We provide some default conf files:
+
+* [containers.conf](containers.conf)
+* [registries.conf](registries.conf)
+    * Add `docker.io` into the default registries for keeping compatible
+* [storage.conf](storage.conf)
+

--- a/base/containers.conf
+++ b/base/containers.conf
@@ -1,0 +1,3 @@
+[engine]
+cgroup_manager="cgroupfs"
+events_logger="file"

--- a/base/hack/install_utils.sh
+++ b/base/hack/install_utils.sh
@@ -1,24 +1,25 @@
 #!/usr/bin/env bash
 
-
 ARCH=$(uname -m)
 
 echo $ARCH
 
-# Docker
-DOCKER_VERSION=18.09.9
-if [[ ${ARCH} == 'x86_64' ]]; then
-  curl -f https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz | tar xvz && \
-  mv docker/docker /usr/bin/ && \
-  rm -rf docker
-elif [[ ${ARCH} == 'aarch64' ]]
-then
-  curl -f https://download.docker.com/linux/static/stable/aarch64/docker-$DOCKER_VERSION.tgz | tar xvz && \
-  mv docker/docker /usr/bin/ && \
-  rm -rf docker
-else
-  echo "do not support this arch"
-  exit 1
+if [[ ${EXCLUDE_DOCKER} != '1' ]]; then
+  # Docker
+  DOCKER_VERSION=18.09.9
+  if [[ ${ARCH} == 'x86_64' ]]; then
+    curl -f https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz | tar xvz && \
+    mv docker/docker /usr/bin/ && \
+    rm -rf docker
+  elif [[ ${ARCH} == 'aarch64' ]]
+  then
+    curl -f https://download.docker.com/linux/static/stable/aarch64/docker-$DOCKER_VERSION.tgz | tar xvz && \
+    mv docker/docker /usr/bin/ && \
+    rm -rf docker
+  else
+    echo "do not support this arch"
+    exit 1
+  fi
 fi
 
 # Helm

--- a/base/podman/Dockerfile
+++ b/base/podman/Dockerfile
@@ -29,11 +29,9 @@ RUN wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.9.5.tar.gz &
     make && \
     make install && \
     mv /usr/local/git/bin/git /usr/bin/ && \
-    cd ..&& \
+    cd .. && \
     rm -rf git-2.9.5.tar.gz git-2.9.5 && \
     git version
-
-
 
 # Set the locale(en_US.UTF-8)
 ENV LANG en_US.UTF-8
@@ -54,6 +52,18 @@ RUN curl -o sonar_scanner.zip https://binaries.sonarsource.com/Distribution/sona
 ENV PATH $PATH:/usr/bin/sonar-scanner-$SONAR_SCANNER_VERSION-linux/bin
 
 COPY ./ ./
+
+ENV EXCLUDE_DOCKER 1
 RUN ./hack/install_utils.sh && rm -rf ./*
 
-CMD ["docker","version"]
+# Install podman
+RUN curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_7/devel:kubic:libcontainers:stable.repo && \
+    yum -y install podman fuse-overlayfs && \
+    echo "alias docker=podman" >> /root/.bashrc
+
+COPY storage.conf /etc/containers/storage.conf
+COPY containers.conf /etc/containers/containers.conf
+
+VOLUME /var/lib/containers
+
+CMD ["podman", "info"]

--- a/base/registries.conf
+++ b/base/registries.conf
@@ -1,0 +1,2 @@
+[registries.search]
+registries = ["docker.io"]

--- a/base/storage.conf
+++ b/base/storage.conf
@@ -1,0 +1,192 @@
+# This file is is the configuration file for all tools
+# that use the containers/storage library.
+# See man 5 containers-storage.conf for more information
+# The "container storage" table contains all of the server options.
+[storage]
+
+# Default Storage Driver, Must be set for proper operation.
+driver = "overlay"
+
+# Temporary storage location
+runroot = "/run/containers/storage"
+
+# Primary Read/Write location of container storage
+graphroot = "/var/lib/containers/storage"
+
+# Storage path for rootless users
+#
+rootless_storage_path = "$HOME/.local/share/containers/storage"
+
+[storage.options]
+# Storage options to be passed to underlying storage drivers
+
+# AdditionalImageStores is used to pass paths to additional Read/Only image stores
+# Must be comma separated list.
+additionalimagestores = [
+]
+
+# Remap-UIDs/GIDs is the mapping from UIDs/GIDs as they should appear inside of
+# a container, to the UIDs/GIDs as they should appear outside of the container,
+# and the length of the range of UIDs/GIDs.  Additional mapped sets can be
+# listed and will be heeded by libraries, but there are limits to the number of
+# mappings which the kernel will allow when you later attempt to run a
+# container.
+#
+# remap-uids = 0:1668442479:65536
+# remap-gids = 0:1668442479:65536
+
+# Remap-User/Group is a user name which can be used to look up one or more UID/GID
+# ranges in the /etc/subuid or /etc/subgid file.  Mappings are set up starting
+# with an in-container ID of 0 and then a host-level ID taken from the lowest
+# range that matches the specified name, and using the length of that range.
+# Additional ranges are then assigned, using the ranges which specify the
+# lowest host-level IDs first, to the lowest not-yet-mapped in-container ID,
+# until all of the entries have been used for maps.
+#
+# remap-user = "containers"
+# remap-group = "containers"
+
+# Root-auto-userns-user is a user name which can be used to look up one or more UID/GID
+# ranges in the /etc/subuid and /etc/subgid file.  These ranges will be partitioned
+# to containers configured to create automatically a user namespace.  Containers
+# configured to automatically create a user namespace can still overlap with containers
+# having an explicit mapping set.
+# This setting is ignored when running as rootless.
+# root-auto-userns-user = "storage"
+#
+# Auto-userns-min-size is the minimum size for a user namespace created automatically.
+# auto-userns-min-size=1024
+#
+# Auto-userns-max-size is the minimum size for a user namespace created automatically.
+# auto-userns-max-size=65536
+
+[storage.options.overlay]
+# ignore_chown_errors can be set to allow a non privileged user running with
+# a single UID within a user namespace to run containers. The user can pull
+# and use any image even those with multiple uids.  Note multiple UIDs will be
+# squashed down to the default uid in the container.  These images will have no
+# separation between the users in the container. Only supported for the overlay
+# and vfs drivers.
+#ignore_chown_errors = "false"
+
+# Path to an helper program to use for mounting the file system instead of mounting it
+# directly.
+mount_program = "/usr/bin/fuse-overlayfs"
+
+# mountopt specifies comma separated list of extra mount options
+mountopt = "nodev"
+
+# Set to skip a PRIVATE bind mount on the storage home directory.
+# skip_mount_home = "false"
+
+# Size is used to set a maximum size of the container image.
+# size = ""
+
+# ForceMask specifies the permissions mask that is used for new files and
+# directories.
+#
+# The values "shared" and "private" are accepted.
+# Octal permission masks are also accepted.
+#
+#  "": No value specified.
+#     All files/directories, get set with the permissions identified within the
+#     image.
+#  "private": it is equivalent to 0700.
+#     All files/directories get set with 0700 permissions.  The owner has rwx
+#     access to the files. No other users on the system can access the files.
+#     This setting could be used with networked based homedirs.
+#  "shared": it is equivalent to 0755.
+#     The owner has rwx access to the files and everyone else can read, access
+#     and execute them. This setting is useful for sharing containers storage
+#     with other users.  For instance have a storage owned by root but shared
+#     to rootless users as an additional store.
+#     NOTE:  All files within the image are made readable and executable by any
+#     user on the system. Even /etc/shadow within your image is now readable by
+#     any user.
+#
+#   OCTAL: Users can experiment with other OCTAL Permissions.
+#
+#  Note: The force_mask Flag is an experimental feature, it could change in the
+#  future.  When "force_mask" is set the original permission mask is stored in
+#  the "user.containers.override_stat" xattr and the "mount_program" option must
+#  be specified. Mount programs like "/usr/bin/fuse-overlayfs" present the
+#  extended attribute permissions to processes within containers rather then the
+#  "force_mask"  permissions.
+#
+# force_mask = ""
+
+[storage.options.thinpool]
+# Storage Options for thinpool
+
+# autoextend_percent determines the amount by which pool needs to be
+# grown. This is specified in terms of % of pool size. So a value of 20 means
+# that when threshold is hit, pool will be grown by 20% of existing
+# pool size.
+# autoextend_percent = "20"
+
+# autoextend_threshold determines the pool extension threshold in terms
+# of percentage of pool size. For example, if threshold is 60, that means when
+# pool is 60% full, threshold has been hit.
+# autoextend_threshold = "80"
+
+# basesize specifies the size to use when creating the base device, which
+# limits the size of images and containers.
+# basesize = "10G"
+
+# blocksize specifies a custom blocksize to use for the thin pool.
+# blocksize="64k"
+
+# directlvm_device specifies a custom block storage device to use for the
+# thin pool. Required if you setup devicemapper.
+# directlvm_device = ""
+
+# directlvm_device_force wipes device even if device already has a filesystem.
+# directlvm_device_force = "True"
+
+# fs specifies the filesystem type to use for the base device.
+# fs="xfs"
+
+# log_level sets the log level of devicemapper.
+# 0: LogLevelSuppress 0 (Default)
+# 2: LogLevelFatal
+# 3: LogLevelErr
+# 4: LogLevelWarn
+# 5: LogLevelNotice
+# 6: LogLevelInfo
+# 7: LogLevelDebug
+# log_level = "7"
+
+# min_free_space specifies the min free space percent in a thin pool require for
+# new device creation to succeed. Valid values are from 0% - 99%.
+# Value 0% disables
+# min_free_space = "10%"
+
+# mkfsarg specifies extra mkfs arguments to be used when creating the base
+# device.
+# mkfsarg = ""
+
+# metadata_size is used to set the `pvcreate --metadatasize` options when
+# creating thin devices. Default is 128k
+# metadata_size = ""
+
+# Size is used to set a maximum size of the container image.
+# size = ""
+
+# use_deferred_removal marks devicemapper block device for deferred removal.
+# If the thinpool is in use when the driver attempts to remove it, the driver
+# tells the kernel to remove it as soon as possible. Note this does not free
+# up the disk space, use deferred deletion to fully remove the thinpool.
+# use_deferred_removal = "True"
+
+# use_deferred_deletion marks thinpool device for deferred deletion.
+# If the device is busy when the driver attempts to delete it, the driver
+# will attempt to delete device every 30 seconds until successful.
+# If the program using the driver exits, the driver will continue attempting
+# to cleanup the next time the driver is used. Deferred deletion permanently
+# deletes the device and all data stored in device will be lost.
+# use_deferred_deletion = "True"
+
+# xfs_nospace_max_retries specifies the maximum number of retries XFS should
+# attempt to complete IO when ENOSPC (no space) error is returned by
+# underlying storage device.
+# xfs_nospace_max_retries = "0"

--- a/go/podman/Dockerfile
+++ b/go/podman/Dockerfile
@@ -1,0 +1,18 @@
+FROM kubespheredev/builder-base:v3.1.0-podman
+
+RUN yum -y groupinstall 'Development Tools'  && yum -y clean all --enablerepo='*'
+
+ENV GOLANG_VERSION 1.12.10
+
+ENV PATH $PATH:/usr/local/go/bin
+ENV PATH $PATH:/usr/local/
+ENV GOROOT /usr/local/go
+ENV GOPATH=/home/jenkins/go
+ENV PATH $PATH:$GOPATH/bin
+
+COPY ./ ./
+RUN ./hack/install_utils.sh && rm -rf ./*
+
+RUN mkdir -p $GOPATH/bin && mkdir -p $GOPATH/src && mkdir -p $GOPATH/pkg
+
+CMD ["go","version"]

--- a/maven/Dockerfile.podman
+++ b/maven/Dockerfile.podman
@@ -1,0 +1,43 @@
+FROM kubespheredev/builder-base:v3.1.0
+
+# java
+ENV JAVA_VERSIOIN 1.8.0
+RUN yum install -y java-${JAVA_VERSIOIN}-openjdk-devel \
+    java-${JAVA_VERSIOIN}-openjdk-devel.i686
+
+# maven
+ENV MAVEN_VERSION 3.5.3
+RUN curl -f -L https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar -C /opt -xzv
+ENV M2_HOME /opt/apache-maven-$MAVEN_VERSION
+ENV JAVA_HOME /usr/lib/jvm/java-${JAVA_VERSIOIN}-openjdk
+ENV maven.home $M2_HOME
+ENV M2 $M2_HOME/bin
+ENV PATH $M2:$PATH:JAVA_HOME/bin
+
+# ant
+ENV ANT_VERSION 1.10.7
+RUN cd && \
+    wget -q https://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz && \
+    tar -xzf apache-ant-${ANT_VERSION}-bin.tar.gz && \
+    mv apache-ant-${ANT_VERSION} /opt/ant && \
+    rm apache-ant-${ANT_VERSION}-bin.tar.gz
+ENV ANT_HOME /opt/ant
+ENV PATH ${PATH}:/opt/ant/bin
+
+# Set JDK to be 32bit
+COPY set_java $M2
+RUN $M2/set_java && rm $M2/set_java
+
+# Install podman
+RUN curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_7/devel:kubic:libcontainers:stable.repo && \
+    yum -y install podman fuse-overlayfs --exclude container-selinux && \
+    sed -i 's/#mount_program/mount_program/g' /etc/containers/storage.conf
+
+RUN useradd podman; \
+    echo podman:10000:5000 > /etc/subuid; \
+    echo podman:10000:5000 > /etc/subgid;
+
+RUN chmod 644 /etc/containers/containers.conf && \
+    sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
+
+CMD ["mvn","-version"]

--- a/maven/podman/Dockerfile
+++ b/maven/podman/Dockerfile
@@ -1,0 +1,31 @@
+FROM kubespheredev/builder-base:v3.1.0-podman
+
+# java
+ENV JAVA_VERSIOIN 1.8.0
+RUN yum install -y java-${JAVA_VERSIOIN}-openjdk-devel \
+    java-${JAVA_VERSIOIN}-openjdk-devel.i686
+
+# maven
+ENV MAVEN_VERSION 3.5.3
+RUN curl -f -L https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar -C /opt -xzv
+ENV M2_HOME /opt/apache-maven-$MAVEN_VERSION
+ENV JAVA_HOME /usr/lib/jvm/java-${JAVA_VERSIOIN}-openjdk
+ENV maven.home $M2_HOME
+ENV M2 $M2_HOME/bin
+ENV PATH $M2:$PATH:JAVA_HOME/bin
+
+# ant
+ENV ANT_VERSION 1.10.7
+RUN cd && \
+    wget -q https://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz && \
+    tar -xzf apache-ant-${ANT_VERSION}-bin.tar.gz && \
+    mv apache-ant-${ANT_VERSION} /opt/ant && \
+    rm apache-ant-${ANT_VERSION}-bin.tar.gz
+ENV ANT_HOME /opt/ant
+ENV PATH ${PATH}:/opt/ant/bin
+
+# Set JDK to be 32bit
+COPY set_java $M2
+RUN $M2/set_java && rm $M2/set_java
+
+CMD ["mvn","-version"]

--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -23,9 +23,7 @@ RUN ARCH= && uArch="$(uname -m)" \
     A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
     B9E2F5981AA6E0CD28160D9FF13993A75599653C \
   ; do \
-    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+    gpg --batch --keyserver sks.srv.dumain.com --recv-keys "$key"; \
   done \
   && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
   && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/nodejs/podman/Dockerfile
+++ b/nodejs/podman/Dockerfile
@@ -1,0 +1,45 @@
+FROM kubespheredev/builder-base:v3.1.0-podman
+
+ENV NODE_VERSION 10.16.3
+
+RUN ARCH= && uArch="$(uname -m)" \
+  && case "${uArch##*-}" in \
+    x86_64) ARCH='x64';; \
+    aarch64) ARCH='arm64';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  # gpg keys listed at https://github.com/nodejs/node#release-keys
+  && set -ex \
+  && for key in \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    77984A986EBC2AA786BC0F66B01FBB92821C587A \
+    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+    4ED778F539E3634C779C87C6D7062848A1AB005C \
+    A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+    B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+  ; do \
+    gpg --batch --keyserver sks.srv.dumain.com --recv-keys "$key"; \
+  done \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && yum install -y nodejs gcc-c++ make bzip2 GConf2 gtk2 chromedriver chromium xorg-x11-server-Xvfb
+
+RUN npm i -g watch-cli vsce typescript
+
+# Yarn
+ENV YARN_VERSION 1.16.0
+RUN curl -f -L -o /tmp/yarn.tgz https://github.com/yarnpkg/yarn/releases/download/v${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz && \
+	tar xf /tmp/yarn.tgz && \
+	mv yarn-v${YARN_VERSION} /opt/yarn && \
+	ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn && \
+	yarn config set cache-folder /root/.yarn


### PR DESCRIPTION
Before this PR, Docker is the container runtime on the base image. In order to keep compatible, I didn't remove docker from the base image directly. Instead, I create a variant image via an image tag. All the images which contain Podman will have the suffix `-podman`. Such as `ghcr.io/kubesphere/builder-base:v3.1.0-podman`

This is part of https://github.com/kubesphere/ks-devops/issues/67