### PR TITLE
Create composite GitHub action to simplify workflow configuration

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,115 @@
+name: Build template
+description: "Template for docker build."
+
+inputs:
+  context:
+    description: Build context for docker.
+    required: true
+  dockerfile:
+    description: Dockerfile location.
+    required: true
+  image-name:
+    description: Docker image name.
+    required: true
+  tag-suffix:
+    description: Suffix of tag name.
+    required: true
+    default: ""
+  platforms:
+    description: Builder node platforms available (comma separated).
+    required: true
+    default: "linux/amd64"
+  build-args:
+    description: List of build-time variables.
+    required: false
+    default: ""
+  docker-registry:
+    description: Docker registry.
+    required: false
+    default: docker.io
+  docker-namespace:
+    description: Docker namespace.
+    required: false
+    default: ""
+  docker-password:
+    description: Password of current docker namespace in docker registry.
+    required: false
+    default: ""
+  ghcr-token:
+    description: Token of current GitHub account in GitHub container registry.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v2
+    - name: Docker meta for KubeSphere
+      id: meta
+      if: github.repository_owner == 'kubesphere'
+      uses: docker/metadata-action@v3
+      with:
+        images: |
+          kubespheredev/${{ inputs.image-name }}
+          ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}
+        tags: |
+          type=ref,event=branch,suffix=${{ inputs.tag-suffix }}
+          type=ref,event=pr,suffix=${{ inputs.tag-suffix }}
+          type=semver,pattern=v{{version}}${{ inputs.tag-suffix }}
+          type=semver,pattern=v{{major}}.{{minor}}${{ inputs.tag-suffix }}
+          type=semver,pattern=v{{major}}${{ inputs.tag-suffix }}
+          type=sha,suffix=${{ inputs.tag-suffix }}
+    - name: Docker meta for Contributors
+      id: metaContributors
+      if: github.repository_owner != 'kubesphere'
+      uses: docker/metadata-action@v3
+      with:
+        images: |
+          ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}
+        tags: |
+          type=ref,event=branch,suffix=${{ inputs.tag-suffix }}
+          type=ref,event=pr,suffix=${{ inputs.tag-suffix }}
+          type=semver,pattern=v{{version}}${{ inputs.tag-suffix }}
+          type=semver,pattern=v{{major}}.{{minor}}${{ inputs.tag-suffix }}
+          type=semver,pattern=v{{major}}${{ inputs.tag-suffix }}
+          type=sha,suffix=${{ inputs.tag-suffix }}
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      if: github.event_name != 'pull_request' && github.repository_owner == 'kubesphere'
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ inputs.docker-registry }}
+        username: ${{ inputs.docker-namespace }}
+        password: ${{ inputs.docker-password }}
+    - name: Login to GHCR
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ inputs.ghcr-token }}
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v2
+      if: github.repository_owner == 'kubesphere'
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.dockerfile }}
+        tags: ${{ steps.meta.outputs.tags }}
+        push: ${{ github.event_name != 'pull_request' }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: ${{ inputs.platforms }}
+        build-args: ${{ inputs.build-args }}
+    - name: Build and push Docker images for Contributors
+      uses: docker/build-push-action@v2
+      if: github.repository_owner != 'kubesphere'
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.dockerfile }}
+        tags: ${{ steps.metaContributors.outputs.tags }}
+        push: ${{ github.event_name != 'pull_request' }}
+        labels: ${{ steps.metaContributors.outputs.labels }}
+        platforms: ${{ inputs.platforms }}
+        build-args: ${{ inputs.build-args }}

--- a/.github/workflows/build-podman.yaml
+++ b/.github/workflows/build-podman.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - refactor/*
     - test-* # make it be easier for contributors to test
     tags:
       - 'v*.*.*'
@@ -15,418 +16,137 @@ jobs:
   BuildBase:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - name: Docker meta for KubeSphere
-      id: meta
-      if: github.repository_owner == 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          kubespheredev/builder-base
-          ghcr.io/${{ github.repository_owner }}/builder-base
-        tags: |
-          type=schedule
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern=v{{version}}-podman
-          type=sha
-    - name: Docker meta for Contributors
-      id: metaContributors
-      if: github.repository_owner != 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          ghcr.io/${{ github.repository_owner }}/builder-base
-        tags: |
-          type=schedule
-          type=ref,event=branch,suffix=-podman
-          type=ref,event=pr,suffix=-podman
-          type=semver,pattern=v{{version}}-podman
-          type=sha,suffix=-podman
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Login to DockerHub
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_HUB_USER }}
-        password: ${{ secrets.DOCKER_HUB_SECRETS }}
-    - name: Login to GHCR
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_TOKEN }}
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner == 'kubesphere'
-      with:
-        context: base
-        file: base/podman/Dockerfile
-        tags: ${{ steps.meta.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.meta.outputs.labels }}
-        platforms: linux/amd64
-    - name: Build and push Docker images for Contributors
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner != 'kubesphere'
-      with:
-        context: base
-        file: base/podman/Dockerfile
-        tags: ${{ steps.metaContributors.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.metaContributors.outputs.labels }}
-        platforms: linux/amd64
+      - uses: actions/checkout@v2
+      - name: Build base agent
+        uses: ./.github/actions/build
+        with:
+          context: base
+          dockerfile: base/podman/Dockerfile
+          image-name: builder-base
+          tag-suffix: -podman
+          platforms: linux/amd64
+          docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
+          docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
+          ghcr-token: ${{ secrets.GHCR_TOKEN }}
 
   BuildGo:
     needs: BuildBase
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Docker meta for KubeSphere
-      id: meta
-      if: github.repository_owner == 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          kubespheredev/builder-go
-          ghcr.io/${{ github.repository_owner }}/builder-go
-        tags: |
-          type=schedule
-          type=ref,event=branch,suffix=-podman
-          type=ref,event=pr,suffix=-podman
-          type=semver,pattern=v{{version}}-podman
-          type=sha,suffix=-podman
-    - name: Docker meta for Contributors
-      id: metaContributors
-      if: github.repository_owner != 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          ghcr.io/${{ github.repository_owner }}/builder-go
-        tags: |
-          type=schedule
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern=v{{version}}-podman
-          type=sha
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Login to DockerHub
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_HUB_USER }}
-        password: ${{ secrets.DOCKER_HUB_SECRETS }}
-    - name: Login to GHCR
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_TOKEN }}
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner == 'kubesphere'
+    - name: Build Go agent
+      uses: ./.github/actions/build
       with:
         context: go
-        file: go/podman/Dockerfile
-        tags: ${{ steps.meta.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.meta.outputs.labels }}
+        dockerfile: go/podman/Dockerfile
+        image-name: builder-go
+        tag-suffix: -podman
         platforms: linux/amd64
-    - name: Build and push Docker images for Contributors
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner != 'kubesphere'
+        docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
+        docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
+        ghcr-token: ${{ secrets.GHCR_TOKEN }}
+        build-args: "GOLANG_VERSION=1.12.10"
+
+  BuildGo16:
+    needs: BuildBase
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build Go 1.16 agent
+      uses: ./.github/actions/build
       with:
         context: go
-        file: go/podman/Dockerfile
-        tags: ${{ steps.metaContributors.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.metaContributors.outputs.labels }}
+        dockerfile: go/podman/Dockerfile
+        image-name: builder-go
+        tag-suffix: -1.16-podman
         platforms: linux/amd64
+        docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
+        docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
+        ghcr-token: ${{ secrets.GHCR_TOKEN }}
+        build-args: "GOLANG_VERSION=1.16.8"
 
   BuildMaven:
     needs: BuildBase
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Docker meta for KubeSphere
-      id: meta
-      if: github.repository_owner == 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          kubespheredev/builder-maven
-          ghcr.io/${{ github.repository_owner }}/builder-maven
-        tags: |
-          type=schedule
-          type=ref,event=branch,suffix=-podman
-          type=ref,event=pr,suffix=-podman
-          type=semver,pattern=v{{version}}-podman
-          type=sha,suffix=-podman
-    - name: Docker meta for Contributors
-      id: metaContributors
-      if: github.repository_owner != 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          ghcr.io/${{ github.repository_owner }}/builder-maven
-        tags: |
-          type=schedule
-          type=ref,event=branch,suffix=-podman
-          type=ref,event=pr,suffix=-podman
-          type=semver,pattern=v{{version}}-podman
-          type=sha,suffix=-podman
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Login to DockerHub
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_HUB_USER }}
-        password: ${{ secrets.DOCKER_HUB_SECRETS }}
-    - name: Login to GHCR
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_TOKEN }}
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner == 'kubesphere'
+    - name: Build maven agent
+      uses: ./.github/actions/build
       with:
         context: maven
-        file: maven/podman/Dockerfile
-        tags: ${{ steps.meta.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.meta.outputs.labels }}
+        dockerfile: maven/podman/Dockerfile
+        image-name: builder-maven
+        tag-suffix: -podman
         platforms: linux/amd64
-    - name: Build and push Docker images for Contributors
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner != 'kubesphere'
+        docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
+        docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
+        ghcr-token: ${{ secrets.GHCR_TOKEN }}
+        build-args: "JDK_VERSION=1.8.0"
+  BuildMavenJDK11:
+    needs: BuildBase
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build maven(JDK11) agent
+      uses: ./.github/actions/build
       with:
         context: maven
-        file: maven/podman/Dockerfile
-        tags: ${{ steps.metaContributors.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.metaContributors.outputs.labels }}
+        dockerfile: maven/podman/Dockerfile
+        image-name: builder-maven
+        tag-suffix: -jdk11-podman
         platforms: linux/amd64
+        docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
+        docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
+        ghcr-token: ${{ secrets.GHCR_TOKEN }}
+        build-args: "JDK_VERSION=11"
 
   BuildGradle:
     needs: BuildBase
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Docker meta for KubeSphere
-        id: meta
-        if: github.repository_owner == 'kubesphere'
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            kubespheredev/builder-gradle
-            ghcr.io/${{ github.repository_owner }}/builder-gradle
-          tags: |
-            type=schedule
-            type=ref,event=branch,suffix=-podman
-            type=ref,event=pr,suffix=-podman
-            type=semver,pattern=v{{version}}-podman
-            type=sha,suffix=-podman
-      - name: Docker meta for Contributors
-        id: metaContributors
-        if: github.repository_owner != 'kubesphere'
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            ghcr.io/${{ github.repository_owner }}/builder-gradle
-          tags: |
-            type=schedule
-            type=ref,event=branch,suffix=-podman
-            type=ref,event=pr,suffix=-podman
-            type=semver,pattern=v{{version}}-podman
-            type=sha,suffix=-podman
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_SECRETS }}
-      - name: Login to GHCR
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v2.4.0
-        if: github.repository_owner == 'kubesphere'
-        with:
-          context: gradle
-          file: gradle/podman/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
-      - name: Build and push Docker images for Contributors
-        uses: docker/build-push-action@v2.4.0
-        if: github.repository_owner != 'kubesphere'
-        with:
-          context: gradle
-          file: gradle/podman/Dockerfile
-          tags: ${{ steps.metaContributors.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
-          labels: ${{ steps.metaContributors.outputs.labels }}
-          platforms: linux/amd64
-
-  BuildNodeJs:
-    needs: BuildBase
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Docker meta for KubeSphere
-      id: meta
-      if: github.repository_owner == 'kubesphere'
-      uses: docker/metadata-action@v3
+    - name: Build Gradle agent
+      uses: ./.github/actions/build
       with:
-        images: |
-          kubespheredev/builder-nodejs
-          ghcr.io/${{ github.repository_owner }}/builder-nodejs
-        tags: |
-          type=schedule
-          type=ref,event=branch,suffix=-podman
-          type=ref,event=pr,suffix=-podman
-          type=semver,pattern=v{{version}}-podman
-          type=sha,suffix=-podman
-    - name: Docker meta for Contributors
-      id: metaContributors
-      if: github.repository_owner != 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          ghcr.io/${{ github.repository_owner }}/builder-nodejs
-        tags: |
-          type=schedule
-          type=ref,event=branch,suffix=-podman
-          type=ref,event=pr,suffix=-podman
-          type=semver,pattern=v{{version}}-podman
-          type=sha,suffix=-podman
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Login to DockerHub
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_HUB_USER }}
-        password: ${{ secrets.DOCKER_HUB_SECRETS }}
-    - name: Login to GHCR
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_TOKEN }}
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner == 'kubesphere'
+        context: gradle
+        dockerfile: gradle/podman/Dockerfile
+        image-name: builder-gradle
+        tag-suffix: -podman
+        platforms: linux/amd64
+        docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
+        docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
+        ghcr-token: ${{ secrets.GHCR_TOKEN }}
+  
+  BuildNodeJs:
+    needs: BuildBase
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build NodeJS agent
+      uses: ./.github/actions/build
       with:
         context: nodejs
-        file: nodejs/podman/Dockerfile
-        tags: ${{ steps.meta.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.meta.outputs.labels }}
+        dockerfile: nodejs/podman/Dockerfile
+        image-name: builder-nodejs
+        tag-suffix: -podman
         platforms: linux/amd64
-    - name: Build and push Docker images for Contributors
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner != 'kubesphere'
-      with:
-        context: nodejs
-        file: nodejs/podman/Dockerfile
-        tags: ${{ steps.metaContributors.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.metaContributors.outputs.labels }}
-        platforms: linux/amd64
+        docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
+        docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
+        ghcr-token: ${{ secrets.GHCR_TOKEN }}
 
   BuildPython:
     needs: BuildBase
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Docker meta for KubeSphere
-        id: meta
-        if: github.repository_owner == 'kubesphere'
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            kubespheredev/builder-python
-            ghcr.io/${{ github.repository_owner }}/builder-python
-          tags: |
-            type=schedule
-            type=ref,event=branch,suffix=-podman
-            type=ref,event=pr,suffix=-podman
-            type=semver,pattern=v{{version}}-podman
-            type=sha,suffix=-podman
-      - name: Docker meta for Contributors
-        id: metaContributors
-        if: github.repository_owner != 'kubesphere'
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            ghcr.io/${{ github.repository_owner }}/builder-python
-          tags: |
-            type=schedule
-            type=ref,event=branch,suffix=-podman
-            type=ref,event=pr,suffix=-podman
-            type=semver,pattern=v{{version}}-podman
-            type=sha,suffix=-podman
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_SECRETS }}
-      - name: Login to GHCR
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v2.4.0
-        if: github.repository_owner == 'kubesphere'
-        with:
-          context: python
-          file: python/podman/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
-      - name: Build and push Docker images for Contributors
-        uses: docker/build-push-action@v2.4.0
-        if: github.repository_owner != 'kubesphere'
-        with:
-          context: python
-          file: python/podman/Dockerfile
-          tags: ${{ steps.metaContributors.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
-          labels: ${{ steps.metaContributors.outputs.labels }}
-          platforms: linux/amd64
+    - uses: actions/checkout@v2
+    - name: Build Python agent
+      uses: ./.github/actions/build
+      with:
+        context: python
+        dockerfile: python/podman/Dockerfile
+        image-name: builder-python
+        tag-suffix: -podman
+        platforms: linux/amd64
+        docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
+        docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
+        ghcr-token: ${{ secrets.GHCR_TOKEN }}

--- a/.github/workflows/build-podman.yaml
+++ b/.github/workflows/build-podman.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-    - refactor/*
     - test-* # make it be easier for contributors to test
     tags:
       - 'v*.*.*'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-    - refactor/*
     - test-* # make it be easier for contributors to test
     tags:
       - 'v*.*.*'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - refactor/*
     - test-* # make it be easier for contributors to test
     tags:
       - 'v*.*.*'
@@ -15,655 +16,147 @@ jobs:
   BuildBase:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - name: Docker meta for KubeSphere
-      id: meta
-      if: github.repository_owner == 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          kubespheredev/builder-base
-          ghcr.io/${{ github.repository_owner }}/builder-base
-        tags: |
-          type=schedule
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern=v{{version}}
-          type=semver,pattern=v{{major}}.{{minor}}
-          type=semver,pattern=v{{major}}
-          type=sha
-    - name: Docker meta for Contributors
-      id: metaContributors
-      if: github.repository_owner != 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          ghcr.io/${{ github.repository_owner }}/builder-base
-        tags: |
-          type=schedule
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern=v{{version}}
-          type=semver,pattern=v{{major}}.{{minor}}
-          type=semver,pattern=v{{major}}
-          type=sha
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Login to DockerHub
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_HUB_USER }}
-        password: ${{ secrets.DOCKER_HUB_SECRETS }}
-    - name: Login to GHCR
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_TOKEN }}
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner == 'kubesphere'
-      with:
-        context: base
-        file: base/Dockerfile
-        tags: ${{ steps.meta.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.meta.outputs.labels }}
-        platforms: linux/amd64,linux/arm64
-    - name: Build and push Docker images for Contributors
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner != 'kubesphere'
-      with:
-        context: base
-        file: base/Dockerfile
-        tags: ${{ steps.metaContributors.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.metaContributors.outputs.labels }}
-        platforms: linux/amd64,linux/arm64
+      - uses: actions/checkout@v2
+      - name: Build base agent
+        uses: ./.github/actions/build
+        with:
+          context: base
+          dockerfile: base/Dockerfile
+          image-name: builder-base
+          platforms: linux/amd64,linux/arm64
+          docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
+          docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
+          ghcr-token: ${{ secrets.GHCR_TOKEN }}
 
   BuildGo:
     needs: BuildBase
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Docker meta for KubeSphere
-      id: meta
-      if: github.repository_owner == 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          kubespheredev/builder-go
-          ghcr.io/${{ github.repository_owner }}/builder-go
-        tags: |
-          type=schedule
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern=v{{version}}
-          type=semver,pattern=v{{major}}.{{minor}}
-          type=semver,pattern=v{{major}}
-          type=sha
-    - name: Docker meta for Contributors
-      id: metaContributors
-      if: github.repository_owner != 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          ghcr.io/${{ github.repository_owner }}/builder-go
-        tags: |
-          type=schedule
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern=v{{version}}
-          type=semver,pattern=v{{major}}.{{minor}}
-          type=semver,pattern=v{{major}}
-          type=sha
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Login to DockerHub
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_HUB_USER }}
-        password: ${{ secrets.DOCKER_HUB_SECRETS }}
-    - name: Login to GHCR
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_TOKEN }}
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner == 'kubesphere'
+    - name: Build Go agent
+      uses: ./.github/actions/build
       with:
         context: go
-        file: go/Dockerfile
-        tags: ${{ steps.meta.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.meta.outputs.labels }}
+        dockerfile: go/Dockerfile
+        image-name: builder-go
         platforms: linux/amd64,linux/arm64
-        build-args: "GOLANG_VERSION=1.12.10"
-    - name: Build and push Docker images for Contributors
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner != 'kubesphere'
-      with:
-        context: go
-        file: go/Dockerfile
-        tags: ${{ steps.metaContributors.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.metaContributors.outputs.labels }}
-        platforms: linux/amd64,linux/arm64
+        docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
+        docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
+        ghcr-token: ${{ secrets.GHCR_TOKEN }}
         build-args: "GOLANG_VERSION=1.12.10"
 
   BuildGo16:
     needs: BuildBase
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Docker meta for KubeSphere
-      id: meta
-      if: github.repository_owner == 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          kubespheredev/builder-go
-          ghcr.io/${{ github.repository_owner }}/builder-go
-        tags: |
-          type=ref,event=branch,suffix=-1.16
-          type=ref,event=pr,suffix=-1.16
-          type=semver,pattern=v{{version}},suffix=-1.16
-    - name: Docker meta for Contributors
-      id: metaContributors
-      if: github.repository_owner != 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          ghcr.io/${{ github.repository_owner }}/builder-go
-        tags: |
-          type=ref,event=branch,suffix=-1.16
-          type=ref,event=pr,suffix=-1.16
-          type=semver,pattern=v{{version}},suffix=-1.16
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Login to DockerHub
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_HUB_USER }}
-        password: ${{ secrets.DOCKER_HUB_SECRETS }}
-    - name: Login to GHCR
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_TOKEN }}
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner == 'kubesphere'
+    - name: Build Go 1.16 agent
+      uses: ./.github/actions/build
       with:
         context: go
-        file: go/Dockerfile
-        tags: ${{ steps.meta.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.meta.outputs.labels }}
+        dockerfile: go/Dockerfile
+        image-name: builder-go
+        tag-suffix: -1.16
         platforms: linux/amd64,linux/arm64
-        build-args: "GOLANG_VERSION=1.16.8"
-    - name: Build and push Docker images for Contributors
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner != 'kubesphere'
-      with:
-        context: go
-        file: go/Dockerfile
-        tags: ${{ steps.metaContributors.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.metaContributors.outputs.labels }}
-        platforms: linux/amd64,linux/arm64
+        docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
+        docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
+        ghcr-token: ${{ secrets.GHCR_TOKEN }}
         build-args: "GOLANG_VERSION=1.16.8"
 
   BuildMaven:
     needs: BuildBase
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Docker meta for KubeSphere
-      id: meta
-      if: github.repository_owner == 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          kubespheredev/builder-maven
-          ghcr.io/${{ github.repository_owner }}/builder-maven
-        tags: |
-          type=schedule
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern=v{{version}}
-          type=semver,pattern=v{{major}}.{{minor}}
-          type=semver,pattern=v{{major}}
-          type=sha
-    - name: Docker meta for Contributors
-      id: metaContributors
-      if: github.repository_owner != 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          ghcr.io/${{ github.repository_owner }}/builder-maven
-        tags: |
-          type=schedule
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern=v{{version}}
-          type=semver,pattern=v{{major}}.{{minor}}
-          type=semver,pattern=v{{major}}
-          type=sha
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Login to DockerHub
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_HUB_USER }}
-        password: ${{ secrets.DOCKER_HUB_SECRETS }}
-    - name: Login to GHCR
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_TOKEN }}
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner == 'kubesphere'
+    - name: Build maven agent
+      uses: ./.github/actions/build
       with:
         context: maven
-        file: maven/Dockerfile
-        tags: ${{ steps.meta.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.meta.outputs.labels }}
+        dockerfile: maven/Dockerfile
+        image-name: builder-maven
         platforms: linux/amd64,linux/arm64
+        docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
+        docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
+        ghcr-token: ${{ secrets.GHCR_TOKEN }}
         build-args: "JDK_VERSION=1.8.0"
-    - name: Build and push Docker images for Contributors
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner != 'kubesphere'
-      with:
-        context: maven
-        file: maven/Dockerfile
-        tags: ${{ steps.metaContributors.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.metaContributors.outputs.labels }}
-        platforms: linux/amd64,linux/arm64
-        build-args: "JDK_VERSION=1.8.0"
-
   BuildMavenJDK11:
     needs: BuildBase
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Docker meta for KubeSphere
-      id: meta
-      if: github.repository_owner == 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          kubespheredev/builder-maven
-          ghcr.io/${{ github.repository_owner }}/builder-maven
-        tags: |
-          type=ref,event=branch,suffix=jdk11
-          type=ref,event=pr,suffix=jdk11
-          type=semver,pattern=v{{version}},suffix=jdk11
-    - name: Docker meta for Contributors
-      id: metaContributors
-      if: github.repository_owner != 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          ghcr.io/${{ github.repository_owner }}/builder-maven
-        tags: |
-          type=ref,event=branch,suffix=jdk11
-          type=ref,event=pr,suffix=jdk11
-          type=semver,pattern=v{{version}},suffix=jdk11
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Login to DockerHub
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_HUB_USER }}
-        password: ${{ secrets.DOCKER_HUB_SECRETS }}
-    - name: Login to GHCR
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_TOKEN }}
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner == 'kubesphere'
+    - name: Build maven(JDK11) agent
+      uses: ./.github/actions/build
       with:
         context: maven
-        file: maven/Dockerfile
-        tags: ${{ steps.meta.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.meta.outputs.labels }}
+        dockerfile: maven/Dockerfile
+        image-name: builder-maven
+        tag-suffix: -jdk11
         platforms: linux/amd64,linux/arm64
-        build-args: "JDK_VERSION=11"
-    - name: Build and push Docker images for Contributors
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner != 'kubesphere'
-      with:
-        context: maven
-        file: maven/Dockerfile
-        tags: ${{ steps.metaContributors.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.metaContributors.outputs.labels }}
-        platforms: linux/amd64,linux/arm64
+        docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
+        docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
+        ghcr-token: ${{ secrets.GHCR_TOKEN }}
         build-args: "JDK_VERSION=11"
 
   BuildGradle:
     needs: BuildBase
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Docker meta for KubeSphere
-        id: meta
-        if: github.repository_owner == 'kubesphere'
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            kubespheredev/builder-gradle
-            ghcr.io/${{ github.repository_owner }}/builder-gradle
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{major}}
-            type=sha
-      - name: Docker meta for Contributors
-        id: metaContributors
-        if: github.repository_owner != 'kubesphere'
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            ghcr.io/${{ github.repository_owner }}/builder-gradle
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{major}}
-            type=sha
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_SECRETS }}
-      - name: Login to GHCR
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v2.4.0
-        if: github.repository_owner == 'kubesphere'
-        with:
-          context: gradle
-          file: gradle/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-      - name: Build and push Docker images for Contributors
-        uses: docker/build-push-action@v2.4.0
-        if: github.repository_owner != 'kubesphere'
-        with:
-          context: gradle
-          file: gradle/Dockerfile
-          tags: ${{ steps.metaContributors.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
-          labels: ${{ steps.metaContributors.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-
+    - uses: actions/checkout@v2
+    - name: Build Gradle agent
+      uses: ./.github/actions/build
+      with:
+        context: gradle
+        dockerfile: gradle/Dockerfile
+        image-name: builder-gradle
+        platforms: linux/amd64,linux/arm64
+        docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
+        docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
+        ghcr-token: ${{ secrets.GHCR_TOKEN }}
+  
   BuildNodeJs:
     needs: BuildBase
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Docker meta for KubeSphere
-      id: meta
-      if: github.repository_owner == 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          kubespheredev/builder-nodejs
-          ghcr.io/${{ github.repository_owner }}/builder-nodejs
-        tags: |
-          type=schedule
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern=v{{version}}
-          type=semver,pattern=v{{major}}.{{minor}}
-          type=semver,pattern=v{{major}}
-          type=sha
-    - name: Docker meta for Contributors
-      id: metaContributors
-      if: github.repository_owner != 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          ghcr.io/${{ github.repository_owner }}/builder-nodejs
-        tags: |
-          type=schedule
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern=v{{version}}
-          type=semver,pattern=v{{major}}.{{minor}}
-          type=semver,pattern=v{{major}}
-          type=sha
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Login to DockerHub
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_HUB_USER }}
-        password: ${{ secrets.DOCKER_HUB_SECRETS }}
-    - name: Login to GHCR
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_TOKEN }}
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner == 'kubesphere'
+    - name: Build NodeJS agent
+      uses: ./.github/actions/build
       with:
         context: nodejs
-        file: nodejs/Dockerfile
-        tags: ${{ steps.meta.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.meta.outputs.labels }}
+        dockerfile: nodejs/Dockerfile
+        image-name: builder-nodejs
         platforms: linux/amd64,linux/arm64
-    - name: Build and push Docker images for Contributors
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner != 'kubesphere'
-      with:
-        context: nodejs
-        file: nodejs/Dockerfile
-        tags: ${{ steps.metaContributors.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.metaContributors.outputs.labels }}
-        platforms: linux/amd64,linux/arm64
+        docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
+        docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
+        ghcr-token: ${{ secrets.GHCR_TOKEN }}
 
   BuildDotnet:
-    runs-on: ubuntu-latest
+    needs: BuildBase
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Docker meta for KubeSphere
-      id: meta
-      if: github.repository_owner == 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          kubespheredev/builder-dotnet
-          ghcr.io/${{ github.repository_owner }}/builder-dotnet
-        tags: |
-          type=schedule
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern=v{{version}}
-          type=semver,pattern=v{{major}}.{{minor}}
-          type=semver,pattern=v{{major}}
-          type=sha
-    - name: Docker meta for Contributors
-      id: metaContributors
-      if: github.repository_owner != 'kubesphere'
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          ghcr.io/${{ github.repository_owner }}/builder-dotnet
-        tags: |
-          type=schedule
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern=v{{version}}
-          type=semver,pattern=v{{major}}.{{minor}}
-          type=semver,pattern=v{{major}}
-          type=sha
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Login to DockerHub
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_HUB_USER }}
-        password: ${{ secrets.DOCKER_HUB_SECRETS }}
-    - name: Login to GHCR
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_TOKEN }}
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner == 'kubesphere'
+    - name: Build DotNet agent
+      uses: ./.github/actions/build
       with:
         context: dotnet
-        file: dotnet/Dockerfile
-        tags: ${{ steps.meta.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.meta.outputs.labels }}
+        dockerfile: dotnet/Dockerfile
+        image-name: builder-dotnet
         platforms: linux/amd64,linux/arm64
-    - name: Build and push Docker images for Contributors
-      uses: docker/build-push-action@v2.4.0
-      if: github.repository_owner != 'kubesphere'
-      with:
-        context: dotnet
-        file: dotnet/Dockerfile
-        tags: ${{ steps.metaContributors.outputs.tags }}
-        push: ${{ github.event_name != 'pull_request' }}
-        labels: ${{ steps.metaContributors.outputs.labels }}
-        platforms: linux/amd64,linux/arm64
+        docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
+        docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
+        ghcr-token: ${{ secrets.GHCR_TOKEN }}
 
   BuildPython:
     needs: BuildBase
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Docker meta for KubeSphere
-        id: meta
-        if: github.repository_owner == 'kubesphere'
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            kubespheredev/builder-python
-            ghcr.io/${{ github.repository_owner }}/builder-python
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{major}}
-            type=sha
-      - name: Docker meta for Contributors
-        id: metaContributors
-        if: github.repository_owner != 'kubesphere'
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            ghcr.io/${{ github.repository_owner }}/builder-python
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{major}}
-            type=sha
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_SECRETS }}
-      - name: Login to GHCR
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v2.4.0
-        if: github.repository_owner == 'kubesphere'
-        with:
-          context: python
-          file: python/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-      - name: Build and push Docker images for Contributors
-        uses: docker/build-push-action@v2.4.0
-        if: github.repository_owner != 'kubesphere'
-        with:
-          context: python
-          file: python/Dockerfile
-          tags: ${{ steps.metaContributors.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
-          labels: ${{ steps.metaContributors.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+    - uses: actions/checkout@v2
+    - name: Build Python agent
+      uses: ./.github/actions/build
+      with:
+        context: python
+        dockerfile: python/Dockerfile
+        image-name: builder-python
+        platforms: linux/amd64,linux/arm64
+        docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
+        docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
+        ghcr-token: ${{ secrets.GHCR_TOKEN }}

--- a/go/podman/Dockerfile
+++ b/go/podman/Dockerfile
@@ -2,7 +2,8 @@ FROM kubespheredev/builder-base:v3.1.0-podman
 
 RUN yum -y groupinstall 'Development Tools'  && yum -y clean all --enablerepo='*'
 
-ENV GOLANG_VERSION 1.12.10
+ARG GOLANG_VERSION 1.12.10
+ENV GOLANG_VERSION $GOLANG_VERSION
 
 ENV PATH $PATH:/usr/local/go/bin
 ENV PATH $PATH:/usr/local/

--- a/maven/podman/Dockerfile
+++ b/maven/podman/Dockerfile
@@ -1,7 +1,9 @@
 FROM kubespheredev/builder-base:v3.1.0-podman
 
+ARG JDK_VERSION 1.8.0
+
 # java
-ENV JAVA_VERSIOIN 1.8.0
+ENV JAVA_VERSIOIN $JDK_VERSION
 RUN yum install -y java-${JAVA_VERSIOIN}-openjdk-devel \
     java-${JAVA_VERSIOIN}-openjdk-devel.i686
 


### PR DESCRIPTION
### What this PR dose?

Create composite GitHub action to simplify workflow configuration.

Below are input variables' details of composite GitHub action:

```yaml
  context:
    description: Build context for docker.
    required: true
  dockerfile:
    description: Dockerfile location.
    required: true
  image-name:
    description: Docker image name.
    required: true
  tag-suffix:
    description: Suffix of tag name.
    required: true
    default: ""
  platforms:
    description: Builder node platforms available (comma separated).
    required: true
    default: "linux/amd64"
  build-args:
    description: List of build-time variables.
    required: false
    default: ""
  docker-registry:
    description: Docker registry.
    required: false
    default: docker.io
  docker-namespace:
    description: Docker namespace.
    required: false
    default: ""
  docker-password:
    description: Password of current docker namespace in docker registry.
    required: false
    default: ""
  ghcr-token:
    description: Token of current GitHub account in GitHub container registry.
    required: false
    default: ""
```

Example of using composite GitHub action:

```yaml
  BuildBase:
    runs-on: ubuntu-20.04
    steps:
      - uses: actions/checkout@v2
      - name: Build base agent
        uses: ./.github/actions/build
        with:
          context: base
          dockerfile: base/Dockerfile
          image-name: builder-base
          platforms: linux/amd64,linux/arm64
          docker-namespace: ${{ secrets.DOCKER_HUB_USER }}
          docker-password: ${{ secrets.DOCKER_HUB_SECRETS }}
          ghcr-token: ${{ secrets.GHCR_TOKEN }}
```

For the result, please see:

- https://github.com/JohnNiang/devops-agent/actions/runs/1458009939
- https://github.com/JohnNiang/devops-agent/actions/runs/1458009940
- ![image](https://user-images.githubusercontent.com/16865714/141667517-b85ecf24-16eb-4f86-809f-78152b8a3aff.png)
- ![image](https://user-images.githubusercontent.com/16865714/141667531-0f6814ce-3d45-489e-a4d3-66af73ed7ab7.png)

### Why do we need it?

At present, our GitHub workflow configuration is highly repetitive and difficult to manage. If we want to add a new agent into this repo, we need to do some error-prone and duplicate works.

### Which issue dose this PR fix?

Fix #53 

/kind feature
/cc @kubesphere/sig-devops 