### PR TITLE
Add kustomize command to the base image

### DIFF
--- a/base/hack/install_utils.sh
+++ b/base/hack/install_utils.sh
@@ -79,3 +79,17 @@ else
   echo "do not support this arch"
   exit 1
 fi
+
+# kustomize
+KUSTOMIZE_VERSION=4.5.3
+if [[ ${ARCH} == 'x86_64' ]]; then
+  curl -fL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz | tar xzv && \
+  mv kustomize /usr/bin/
+elif [[ ${ARCH} == 'aarch64' ]]
+then
+  curl -fL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_arm64.tar.gz | tar xzv && \
+  mv kustomize /usr/bin/
+else
+  echo "do not support this arch"
+  exit 1
+fi


### PR DESCRIPTION
I have tested it manually. See the following output:
```
gitpod /workspace/devops-agent $ docker run surenpi/devops-agent:latest kustomize version
{Version:kustomize/v4.5.3 GitCommit:de6b9784912a5c1df309e6ae9152b962be4eba47 BuildDate:2022-03-24T20:51:20Z GoOs:linux GoArch:amd64}
```

fix #41 