### PR TITLE
Fix the podman command alias

### DIFF
--- a/base/podman/Dockerfile
+++ b/base/podman/Dockerfile
@@ -59,7 +59,7 @@ RUN ./hack/install_utils.sh && rm -rf ./*
 # Install podman
 RUN curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_7/devel:kubic:libcontainers:stable.repo && \
     yum -y install podman fuse-overlayfs && \
-    echo "alias docker=podman" >> /root/.bashrc && \
+    ln -s /usr/bin/podman /usr/bin/docker && \
     yum -y clean all --enablerepo='*'
 
 COPY storage.conf /etc/containers/storage.conf


### PR DESCRIPTION
it would be better to set the command alias as a global one instead of a particular user

I have tested it manually. See the following screenshot:

![image](https://user-images.githubusercontent.com/1450685/161027157-5f8d72b2-cc87-476d-975a-c7d05816a5c0.png)
