### PR TITLE
modified the Maven and Gradle dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,21 @@ It's a better way to provide jenkinsfile for compiling images, like base agent.
 - Mailing list [archive](https://groups.google.com/group/kubesphere-sig-devops/topics) | [subscribe](mailto:kubesphere-sig-devops+subscribe@googlegroups.com) | [unsubscribe](mailto:kubesphere-sig-devops+unsubscribe@googlegroups.com)
 - [Medium (Blog)](https://itnext.io/@kubesphere)
 
+## build maven
+
+```shell
+docker build -t test --build-arg JAVA_VERSIOIN=1.8.0 --build-arg MAVEN_VERSION=3.8.6 .
+```
+
+## build gradle image
+
+```shell
+ docker build -t gradle --build-arg JAVA_VERSIOIN=1.8.0 --build-arg GRADLE_VERSION=7.4.1 .
+```
+
+## build volta image
+
+```
+docker build -t volta --build-arg VERSION=1.0.7
+
+```

--- a/gradle/Dockerfile
+++ b/gradle/Dockerfile
@@ -1,23 +1,313 @@
 FROM kubespheredev/builder-base:v3.1.0
 
 # java
-ENV JAVA_VERSIOIN 1.8.0
-RUN yum install -y java-${JAVA_VERSIOIN}-openjdk-devel java-${JAVA_VERSIOIN}-openjdk-devel.i686 && \
-    yum -y clean all
+ARG JAVA_VERSIOIN 17.0.1
+SHELL ["/bin/bash", "-c"]
+ENV BASH_ENV ~/.bashrc
+ENV JAVA_HOME /usr/local/jdk-${JAVA_VERSIOIN}
+ENV PATH ${JAVA_HOME}/bin:$PATH
 
-# gradle6
-ENV GRADLE_VERSION 6.9.1
+RUN \
+  # Install JDK
+  if [ "$JAVA_VERSIOIN" == "1.8.0" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/openjdk/jdk8u41/ri/openjdk-8u41-b04-linux-x64-14_jan_2020.tar.gz -o openjdk.tar.gz \
+    && mkdir -pv /usr/local/jdk-1.8.0 && tar -zxvf openjdk.tar.gz -C /usr/local/jdk-1.8.0 --strip-components 1 \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "11" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/ga/jdk11/openjdk-11_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/ga/jdk11/openjdk-11_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \   
+  elif [ "$JAVA_VERSIOIN" == "11.0.1" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \ 
+  elif [ "$JAVA_VERSIOIN" == "11.0.2" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \          
+  elif [ "$JAVA_VERSIOIN" == "12" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk12/33/GPL/openjdk-12_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk12/33/GPL/openjdk-12_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "12.0.1" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "12.0.2" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk12.0.2/e482c34c86bd4bf8b56c0b35558996b9/10/GPL/openjdk-12.0.2_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk12.0.2/e482c34c86bd4bf8b56c0b35558996b9/10/GPL/openjdk-12.0.2_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \  
+  elif [ "$JAVA_VERSIOIN" == "13" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk13/5b8a42f3905b406298b72d750b6919f6/33/GPL/openjdk-13_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk13/5b8a42f3905b406298b72d750b6919f6/33/GPL/openjdk-13_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "13.0.1" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "13.0.2" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \          
+  elif [ "$JAVA_VERSIOIN" == "14" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk14/076bab302c7b4508975440c56f6cc26a/36/GPL/openjdk-14_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk14/076bab302c7b4508975440c56f6cc26a/36/GPL/openjdk-14_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "14.0.1" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "14.0.2" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \     
+  elif [ "$JAVA_VERSIOIN" == "15" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "15.0.1" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "15.0.2" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \    
+  elif [ "$JAVA_VERSIOIN" == "16" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/7863447f0ab643c585b9bdebf67c69db/36/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/7863447f0ab643c585b9bdebf67c69db/36/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \    
+  elif [ "$JAVA_VERSIOIN" == "16.0.1" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \  
+  elif [ "$JAVA_VERSIOIN" == "16.0.2" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk16.0.2/d4a915d82b4c4fbb9bde534da945d746/7/GPL/openjdk-16.0.2_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk16.0.2/d4a915d82b4c4fbb9bde534da945d746/7/GPL/openjdk-16.0.2_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \                 
+  elif [ "$JAVA_VERSIOIN" == "17" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl -sLf https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \    
+  elif [ "$JAVA_VERSIOIN" == "17.0.1" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/2a2082e5a09d4267845be086888add4f/12/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl -sLf https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/2a2082e5a09d4267845be086888add4f/12/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "17.0.2" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl -sLf https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \    
+  else \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl -sLf https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  fi \
+  # Test install
+    && ls -l /usr/local/ \
+    && javac -version
+
+# gradle
+ARG GRADLE_VERSION 7.4.2
 ENV GRADLE_HOME /usr/local/gradle-${GRADLE_VERSION}
 ENV PATH ${GRADLE_HOME}/bin:$PATH
 
-RUN curl -fSL https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip -o gradle.zip && \
-    echo "$(curl -sLf https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip.sha256) gradle.zip" | sha256sum --check && \
-    unzip -q gradle.zip -d /usr/local && \
-    rm -f gradle.zip
+RUN curl -fSL https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip -o gradle.zip  \
+    && echo "$(curl -sLf https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip.sha256) gradle.zip" | sha256sum --check  \
+    && unzip -q gradle.zip -d /usr/local  \
+    && rm -f gradle.zip  \
+    && echo "export GRADLE_HOME=/usr/local/gradle-${GRADLE_VERSION}" >> ~/.bashrc  \
+    && echo "export PATH=\"/usr/local/gradle-${GRADLE_VERSION}/bin:$PATH\"" >> ~/.bashrc  \
+    && echo "export GRADLE_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc \
+    && ls -l /usr/local/ \
+    && gradle -v
 
 # Set JDK to be 32bit
-COPY set_java $GRADLE_HOME
-RUN $GRADLE_HOME/set_java && \
-    rm -f $GRADLE_HOME/set_java
+# COPY set_java $GRADLE_HOME
+# RUN $GRADLE_HOME/set_java && \
+#     rm -f $GRADLE_HOME/set_java
 
 CMD ["gradle","--version"]

--- a/gradle/Dockerfile
+++ b/gradle/Dockerfile
@@ -1,7 +1,7 @@
 FROM kubespheredev/builder-base:v3.1.0
 
 # java
-ARG JAVA_VERSIOIN 17.0.1
+ARG JAVA_VERSIOIN=17.0.1
 SHELL ["/bin/bash", "-c"]
 ENV BASH_ENV ~/.bashrc
 ENV JAVA_HOME /usr/local/jdk-${JAVA_VERSIOIN}
@@ -31,7 +31,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \   
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "11.0.1" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -43,7 +43,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \ 
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "11.0.2" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -55,7 +55,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \          
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "12" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -91,7 +91,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \  
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "13" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -127,7 +127,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \          
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "14" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -163,7 +163,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \     
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "15" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -199,7 +199,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \    
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "16" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -211,7 +211,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \    
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "16.0.1" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -223,7 +223,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \  
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "16.0.2" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -235,7 +235,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \                 
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "17" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -247,7 +247,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \    
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "17.0.1" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -271,7 +271,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \    
+    && source ~/.bashrc ; \
   else \
     yum -y remove java-1.8.0-openjdk \
     && curl -fSL https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz -o openjdk.tar.gz \
@@ -289,7 +289,7 @@ RUN \
     && javac -version
 
 # gradle
-ARG GRADLE_VERSION 7.4.2
+ARG GRADLE_VERSION=7.4.2
 ENV GRADLE_HOME /usr/local/gradle-${GRADLE_VERSION}
 ENV PATH ${GRADLE_HOME}/bin:$PATH
 

--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -1,7 +1,7 @@
 FROM kubespheredev/builder-base:v3.1.0
 
 # java
-ARG JAVA_VERSIOIN 17.0.1
+ARG JAVA_VERSIOIN=17.0.1
 SHELL ["/bin/bash", "-c"]
 ENV BASH_ENV ~/.bashrc
 ENV JAVA_HOME /usr/local/jdk-${JAVA_VERSIOIN}
@@ -31,7 +31,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \   
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "11.0.1" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -43,7 +43,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \ 
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "11.0.2" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -55,7 +55,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \          
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "12" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -91,7 +91,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \  
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "13" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -127,7 +127,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \          
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "14" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -163,7 +163,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \     
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "15" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -199,7 +199,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \    
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "16" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -211,7 +211,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \    
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "16.0.1" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -223,7 +223,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \  
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "16.0.2" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -235,7 +235,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \                 
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "17" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -247,7 +247,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \    
+    && source ~/.bashrc ; \
   elif [ "$JAVA_VERSIOIN" == "17.0.1" ]; \
   then \
     yum -y remove java-1.8.0-openjdk \
@@ -271,7 +271,7 @@ RUN \
     && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
     && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
     && cat ~/.bashrc  \
-    && source ~/.bashrc ; \    
+    && source ~/.bashrc ; \
   else \
     yum -y remove java-1.8.0-openjdk \
     && curl -fSL https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz -o openjdk.tar.gz \
@@ -289,7 +289,7 @@ RUN \
     && javac -version
 
 # maven
-ENV MAVEN_VERSION 3.5.3
+ARG MAVEN_VERSION=3.5.3
 RUN curl -f -L https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar -C /opt -xzv
 ENV M2_HOME /opt/apache-maven-$MAVEN_VERSION
 ENV JAVA_HOME /usr/lib/jvm/java-${JAVA_VERSIOIN}-openjdk

--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -290,12 +290,22 @@ RUN \
 
 # maven
 ARG MAVEN_VERSION=3.5.3
-RUN curl -f -L https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar -C /opt -xzv
 ENV M2_HOME /opt/apache-maven-$MAVEN_VERSION
-ENV JAVA_HOME /usr/lib/jvm/java-${JAVA_VERSIOIN}-openjdk
+ENV JAVA_HOME /usr/local/jdk-${JAVA_VERSIOIN}
 ENV maven.home $M2_HOME
 ENV M2 $M2_HOME/bin
 ENV PATH $M2:$PATH:JAVA_HOME/bin
+RUN curl -f -L https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar -C /opt -xzv  \
+    && rm -f gradle.zip  \
+    && echo "export M2_HOME=/opt/apache-maven-${MAVEN_VERSION}" >> ~/.bashrc  \
+    && echo "export MAVEN_HOME=${M2_HOME}" >> ~/.bashrc  \
+    && echo "export M2=${M2_HOME}/bin" >> ~/.bashrc  \
+    && echo "export PATH=\"$M2:$PATH:JAVA_HOME/bin\"" >> ~/.bashrc  \
+    && echo "export M2_HOME MAVEN_HOME M2 PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc \
+    && ls -l /opt \
+    && mvn -v
 
 # ant
 ENV ANT_VERSION 1.10.7

--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -308,7 +308,7 @@ ENV ANT_HOME /opt/ant
 ENV PATH ${PATH}:/opt/ant/bin
 
 # Set JDK to be 32bit
-COPY set_java $M2
-RUN $M2/set_java && rm $M2/set_java
+# COPY set_java $M2
+# RUN $M2/set_java && rm $M2/set_java
 
 CMD ["mvn","-version"]

--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -1,11 +1,292 @@
 FROM kubespheredev/builder-base:v3.1.0
 
-ARG JDK_VERSION 1.8.0
-
 # java
-ENV JAVA_VERSIOIN $JDK_VERSION
-RUN yum install -y java-${JAVA_VERSIOIN}-openjdk-devel \
-    java-${JAVA_VERSIOIN}-openjdk-devel.i686
+ARG JAVA_VERSIOIN 17.0.1
+SHELL ["/bin/bash", "-c"]
+ENV BASH_ENV ~/.bashrc
+ENV JAVA_HOME /usr/local/jdk-${JAVA_VERSIOIN}
+ENV PATH ${JAVA_HOME}/bin:$PATH
+
+RUN \
+  # Install JDK
+  if [ "$JAVA_VERSIOIN" == "1.8.0" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/openjdk/jdk8u41/ri/openjdk-8u41-b04-linux-x64-14_jan_2020.tar.gz -o openjdk.tar.gz \
+    && mkdir -pv /usr/local/jdk-1.8.0 && tar -zxvf openjdk.tar.gz -C /usr/local/jdk-1.8.0 --strip-components 1 \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "11" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/ga/jdk11/openjdk-11_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/ga/jdk11/openjdk-11_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \   
+  elif [ "$JAVA_VERSIOIN" == "11.0.1" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \ 
+  elif [ "$JAVA_VERSIOIN" == "11.0.2" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \          
+  elif [ "$JAVA_VERSIOIN" == "12" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk12/33/GPL/openjdk-12_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk12/33/GPL/openjdk-12_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "12.0.1" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "12.0.2" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk12.0.2/e482c34c86bd4bf8b56c0b35558996b9/10/GPL/openjdk-12.0.2_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk12.0.2/e482c34c86bd4bf8b56c0b35558996b9/10/GPL/openjdk-12.0.2_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \  
+  elif [ "$JAVA_VERSIOIN" == "13" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk13/5b8a42f3905b406298b72d750b6919f6/33/GPL/openjdk-13_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk13/5b8a42f3905b406298b72d750b6919f6/33/GPL/openjdk-13_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "13.0.1" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "13.0.2" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \          
+  elif [ "$JAVA_VERSIOIN" == "14" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk14/076bab302c7b4508975440c56f6cc26a/36/GPL/openjdk-14_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk14/076bab302c7b4508975440c56f6cc26a/36/GPL/openjdk-14_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "14.0.1" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk14.0.1/664493ef4a6946b186ff29eb326336a2/7/GPL/openjdk-14.0.1_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "14.0.2" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \     
+  elif [ "$JAVA_VERSIOIN" == "15" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "15.0.1" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "15.0.2" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \    
+  elif [ "$JAVA_VERSIOIN" == "16" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/7863447f0ab643c585b9bdebf67c69db/36/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/7863447f0ab643c585b9bdebf67c69db/36/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \    
+  elif [ "$JAVA_VERSIOIN" == "16.0.1" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \  
+  elif [ "$JAVA_VERSIOIN" == "16.0.2" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk16.0.2/d4a915d82b4c4fbb9bde534da945d746/7/GPL/openjdk-16.0.2_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl https://download.java.net/java/GA/jdk16.0.2/d4a915d82b4c4fbb9bde534da945d746/7/GPL/openjdk-16.0.2_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \                 
+  elif [ "$JAVA_VERSIOIN" == "17" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl -sLf https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \    
+  elif [ "$JAVA_VERSIOIN" == "17.0.1" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/2a2082e5a09d4267845be086888add4f/12/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl -sLf https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/2a2082e5a09d4267845be086888add4f/12/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  elif [ "$JAVA_VERSIOIN" == "17.0.2" ]; \
+  then \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl -sLf https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \    
+  else \
+    yum -y remove java-1.8.0-openjdk \
+    && curl -fSL https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz -o openjdk.tar.gz \
+    && echo "$(curl -sLf https://download.java.net/java/GA/jdk${JAVA_VERSIOIN}/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-${JAVA_VERSIOIN}_linux-x64_bin.tar.gz.sha256) openjdk.tar.gz" | sha256sum --check  \
+    && tar -zxvf openjdk.tar.gz -C /usr/local \
+    && rm -f openjdk.tar.gz \
+    && echo "export JAVA_HOME=/usr/local/jdk-${JAVA_VERSIOIN}" >> ~/.bashrc \
+    && echo "export PATH=\"/usr/local/jdk-${JAVA_VERSIOIN}/bin:$PATH\"" >> ~/.bashrc \
+    && echo "export JAVA_HOME PATH " >> ~/.bashrc  \
+    && cat ~/.bashrc  \
+    && source ~/.bashrc ; \
+  fi \
+  # Test install
+    && ls -l /usr/local/ \
+    && javac -version
 
 # maven
 ENV MAVEN_VERSION 3.5.3

--- a/volta/Dockerfile
+++ b/volta/Dockerfile
@@ -1,0 +1,32 @@
+FROM kubesphere/builder-base:v3.1.0
+
+# 切换国内源并安装依赖工具包
+RUN mv /etc/yum.repos.d/CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo.backup \
+    && wget -O /etc/yum.repos.d/CentOS-Base.repo https://mirrors.aliyun.com/repo/Centos-7.repo \
+    && yum -y install deltarpm && yum makecache && yum -y update && yum clean all \
+    && yum -y install gcc curl openssl openssl-devel ca-certificates tar perl perl-Module-Load-Conditional && yum clean all
+
+ARG VERSION=latest
+
+ENV VOLTA_VERSION $VERSION
+
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+SHELL ["/bin/bash", "-c"]
+ENV BASH_ENV ~/.bashrc
+ENV VOLTA_HOME /root/.volta
+ENV PATH $VOLTA_HOME/bin:$PATH
+RUN \
+  # Install Volta
+  if [ "$VERSION" = "latest" ]; \
+  then \
+  curl https://get.volta.sh | bash; \
+  else \
+  curl https://get.volta.sh | bash -s -- --version $VERSION; \
+  fi \
+  # Test install
+  && ls -l ~/.volta/bin \
+  && volta --version
+

--- a/volta/Dockerfile
+++ b/volta/Dockerfile
@@ -1,9 +1,7 @@
 FROM kubesphere/builder-base:v3.1.0
 
-# 切换国内源并安装依赖工具包
-RUN mv /etc/yum.repos.d/CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo.backup \
-    && wget -O /etc/yum.repos.d/CentOS-Base.repo https://mirrors.aliyun.com/repo/Centos-7.repo \
-    && yum -y install deltarpm && yum makecache && yum -y update && yum clean all \
+# Install Deploy
+RUN yum -y install deltarpm && yum makecache && yum -y update && yum clean all \
     && yum -y install gcc curl openssl openssl-devel ca-certificates tar perl perl-Module-Load-Conditional && yum clean all
 
 ARG VERSION=latest


### PR DESCRIPTION
I modified the Maven and Gradle dockerfiles to build different versions of the JDK and Maven and Gradle, because Gradle is currently used on a large scale. In addition, I provide Volta Dockerfile, Volta is used to manage front-end Node.js, very convenient, can be used to replace NVM etc.

我修改了 Maven 和 Gradle 的 Dockerfile ，以便构建不同版本的 JDK 和 Maven 以及 Gradle ，因为目前来说，Gradle 已经得到大规模的使用；并且，我提供了 Volta 的 Dockerfile ，Volta 是用来管理前端的 node.js ，非常方便，可以用来替代 nvm 等。